### PR TITLE
immediately fail new tests in pytest-xdist 

### DIFF
--- a/src/xdist/bucketing.py
+++ b/src/xdist/bucketing.py
@@ -1,0 +1,115 @@
+"""\
+Implementation of bin packing / binning algorithm
+to automatically select most optimal set of tests
+to run on each node.
+"""
+import glob
+import json
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+
+def load_bins(path: str | Path | None = None) -> List[List[str]]:
+    """\
+    Between tests we record durations.csv files which record how long each test took to run.
+    We then transform those into a series of bins which evenly distribute the tests.
+    This function loads that bins.json file into memory.
+    """
+    if isinstance(path, str):
+        path = Path(path)
+
+    if path is None:
+        root_dir = os.environ.get("TEST_DIR")
+        if root_dir is None:
+            root_dir = Path.cwd()
+        else:
+            root_dir = Path(root_dir)
+
+        path = root_dir / "bins.json"
+
+    with path.open() as f:
+        return json.load(f)
+
+
+def discover_all_tests() -> List[str]:
+    """\
+    bins.json may not have all of the tests that we want to run.
+    For example: what if someone adds a new test file?
+    Here we collect the remaining set of tests.
+    """
+    python_files = [
+        test
+        for test in glob.glob("tests/**/*.py", recursive=True)
+        if not any(
+            sentinel in test
+            for sentinel in [
+                ".pyc",
+                "__pycache__",
+                "__init__.py",
+                "conftest.py",
+                "tests/incremental",
+            ]
+        )
+    ]
+
+    return [
+        filename
+        for filename in python_files
+        if not any(
+            sentinel in filename
+            for sentinel in [
+                ".pyc",
+                "__pycache__",
+                "__init__.py",
+                "conftest.py",
+                "tests/incremental",
+            ]
+        )
+    ]
+
+
+def find_new_tests(bins: List[List[str]], all_tests: List[str]) -> List[str]:
+    """\
+    Wow! The last docstring was a spoiler!
+    Here we're doing the thing where we find new tests.
+    """
+    bined_tests = set()
+    for bin in bins:
+        bined_tests.update(bin)
+
+    return [
+        test
+        for test in all_tests
+        if test not in bined_tests
+    ]
+
+
+def bin_new_tests(bins: List[List[str]], new_tests: List[str]) -> List[List[str]]:
+    """\
+    And then finally we add the new tests we've discovered to the bins.
+    These are the final bins we use to run the tests.
+    """
+    bins = [[*bin] for bin in bins]
+    for new_test in new_tests:
+        current_min_index = -1
+        current_min_count = -1
+
+        for i, bin in enumerate(bins):
+            count = len(bin)
+            if current_min_count == -1 or count < current_min_count:
+                current_min_index = i
+                current_min_count = count
+
+        bins[current_min_index].append(new_test)
+    return bins
+
+
+def get_bins_and_new_tests() -> Tuple[List[List[str]], List[str]]:
+    bins = load_bins()
+    all_tests = discover_all_tests()
+    new_tests = find_new_tests(bins, all_tests)
+    return (
+        bin_new_tests(bins, new_tests),
+        new_tests,
+    )

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -11,7 +11,6 @@ import sys
 import os
 import time
 from typing import Any
-from typing import List
 
 import pytest
 from execnet.gateway_base import dumps, DumpError

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -347,8 +347,7 @@ def setup_config(config, basetemp):
 
 if __name__ == "__channelexec__":
     channel = channel  # type: ignore[name-defined] # noqa: F821
-    workerinput, args, option_dict, change_sys_path, new_tests = channel.receive()  # type: ignore[name-defined]
-    new_tests: List[str]
+    workerinput, args, option_dict, change_sys_path = channel.receive()  # type: ignore[name-defined]
 
     if change_sys_path is None:
         importpath = os.getcwd()
@@ -373,6 +372,5 @@ if __name__ == "__channelexec__":
     config._parser.prog = os.path.basename(workerinput["mainargv"][0])
     config.workerinput = workerinput  # type: ignore[attr-defined]
     config.workeroutput = {}  # type: ignore[attr-defined]
-    config.new_tests = new_tests  # type: ignore[attr-defined]
     interactor = WorkerInteractor(config, channel)  # type: ignore[name-defined]
     config.hook.pytest_cmdline_main(config=config)

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -11,6 +11,7 @@ import sys
 import os
 import time
 from typing import Any
+from typing import List
 
 import pytest
 from execnet.gateway_base import dumps, DumpError
@@ -346,7 +347,8 @@ def setup_config(config, basetemp):
 
 if __name__ == "__channelexec__":
     channel = channel  # type: ignore[name-defined] # noqa: F821
-    workerinput, args, option_dict, change_sys_path = channel.receive()  # type: ignore[name-defined]
+    workerinput, args, option_dict, change_sys_path, new_tests = channel.receive()  # type: ignore[name-defined]
+    new_tests: List[str]
 
     if change_sys_path is None:
         importpath = os.getcwd()
@@ -371,5 +373,6 @@ if __name__ == "__channelexec__":
     config._parser.prog = os.path.basename(workerinput["mainargv"][0])
     config.workerinput = workerinput  # type: ignore[attr-defined]
     config.workeroutput = {}  # type: ignore[attr-defined]
+    config.new_tests = new_tests  # type: ignore[attr-defined]
     interactor = WorkerInteractor(config, channel)  # type: ignore[name-defined]
     config.hook.pytest_cmdline_main(config=config)

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -4,7 +4,7 @@ import csv
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 import sys
-from traceback import print_stack
+from typing import List
 
 from _pytest.runner import CollectReport
 from _pytest.reports import TestReport
@@ -100,10 +100,7 @@ class LoadScopeScheduling:
 
     RETRIES_MODULE_AND_TEST_REGEX = re.compile('([^:]+)::(.+)')
 
-    def __init__(self, config, log=None):
-        print("<<< __init__")
-        print_stack(file=sys.stdout)
-
+    def __init__(self, config, log=None, *, new_tests: List[str]):
         self.numnodes = len(parse_spec_config(config))
         self.collection = None
 
@@ -120,6 +117,7 @@ class LoadScopeScheduling:
             self.log = log.loadscopesched
 
         self.config = config
+        self.new_tests = new_tests
 
     @property
     def nodes(self):
@@ -288,9 +286,7 @@ class LoadScopeScheduling:
         node.send_runtest_some(nodeids_indexes)
 
     def handle_failed_test(self, node, rep):
-        print("<<< handle_failed_test")
-        print_stack(file=sys.stdout)
-        if rep.nodeid in self.config.new_tests:
+        if rep.nodeid in self.new_tests:
             print(f"Failing test {rep.nodeid} immediately because it is a new test.")
             return True
 

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -3,6 +3,7 @@ import re
 import csv
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
+from traceback import print_stack
 
 from _pytest.runner import CollectReport
 from _pytest.reports import TestReport
@@ -99,6 +100,9 @@ class LoadScopeScheduling:
     RETRIES_MODULE_AND_TEST_REGEX = re.compile('([^:]+)::(.+)')
 
     def __init__(self, config, log=None):
+        print("<<< __init__")
+        print_stack()
+
         self.numnodes = len(parse_spec_config(config))
         self.collection = None
 
@@ -283,6 +287,8 @@ class LoadScopeScheduling:
         node.send_runtest_some(nodeids_indexes)
 
     def handle_failed_test(self, node, rep):
+        print("<<< handle_failed_test")
+        print_stack()
         if rep.nodeid in self.config.new_tests:
             print(f"Failing test {rep.nodeid} immediately because it is a new test.")
             return True

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -3,6 +3,7 @@ import re
 import csv
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
+import sys
 from traceback import print_stack
 
 from _pytest.runner import CollectReport
@@ -101,7 +102,7 @@ class LoadScopeScheduling:
 
     def __init__(self, config, log=None):
         print("<<< __init__")
-        print_stack()
+        print_stack(file=sys.stdout)
 
         self.numnodes = len(parse_spec_config(config))
         self.collection = None
@@ -288,7 +289,7 @@ class LoadScopeScheduling:
 
     def handle_failed_test(self, node, rep):
         print("<<< handle_failed_test")
-        print_stack()
+        print_stack(file=sys.stdout)
         if rep.nodeid in self.config.new_tests:
             print(f"Failing test {rep.nodeid} immediately because it is a new test.")
             return True

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -3,7 +3,6 @@ import re
 import csv
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
-import sys
 from typing import List
 
 from _pytest.runner import CollectReport

--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -283,6 +283,10 @@ class LoadScopeScheduling:
         node.send_runtest_some(nodeids_indexes)
 
     def handle_failed_test(self, node, rep):
+        if rep.nodeid in self.config.new_tests:
+            print(f"Failing test {rep.nodeid} immediately because it is a new test.")
+            return True
+
         if rep.nodeid not in self.retries:
             self.retries[rep.nodeid] = RetryInfo(
                 retry_count=0,

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -101,11 +101,14 @@ class NodeManager:
 
             buckets[current_min_index].append(new_test)
 
-        for i in range(len(buckets)):
-            bucket = buckets[i]
-            buckets[i] = [test for test in bucket if test in all_tests or '__init__.py' in test]
+        for i, bucket in enumerate(buckets):
+            buckets[i] = [
+                test
+                for test in bucket
+                if test in all_tests or '__init__.py' in test
+            ]
 
-        self.buckets = [",".join(path) for path in buckets]
+        self.buckets = buckets
 
     def rsync_roots(self, gateway):
         """Rsync the set of roots to the node's gateway cwd."""
@@ -130,7 +133,7 @@ class NodeManager:
                 self.setup_node(
                     spec,
                     putevent,
-                    self.buckets[i],
+                    ",".join(self.buckets[i]),
                     new_tests_from_bucket,
                 )
             )

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -360,7 +360,7 @@ class WorkerController:
         for path in self.path.split(","):
             args.insert(0, path)
 
-        self.channel.send((self.workerinput, args, option_dict, change_sys_path))
+        self.channel.send((self.workerinput, args, option_dict, change_sys_path, self.new_tests))
 
         if self.putevent:
             self.channel.setcallback(self.process_from_remote, endmarker=self.ENDMARK)


### PR DESCRIPTION
Previous we would retry new tests up to 5 times, which means that flaky tests can more easily be introduced into a CI suite. This PR modifies behavior so we fail immediately when a test has failed if it's a new test. Note that this does not yet include failing a modified test, or a test which covers code that has been modified.